### PR TITLE
Bugfix of missing keys in deep objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,11 +16,15 @@ var diff = function(defaults,source){
 				}
 
 			}else{
-				var tmp = diff(defaults[key],value)
-				if(_.isEmpty(tmp)){
-					delete result[key]
+				if(typeof defaults[ key ] === "undefined"){
+					result[ key ] = value
 				}else{
-					result[key]=tmp
+					var tmp = diff(defaults[ key ], value)
+					if (_.isEmpty(tmp)) {
+						delete result[ key ]
+					} else {
+						result[ key ] = tmp
+					}
 				}
 			}
 

--- a/test/test.js
+++ b/test/test.js
@@ -92,11 +92,15 @@ describe("object deep diff",function(){
 		
 		var sourceObj = {a:{b:{c:"hello"}}}
 		var sourceObj1 = {a:{b:{c:"hello world"}}}
-		
+		var sourceObj2 = {a:{d:{e:"hello world"}}}
+
 		var result = diff(defaultsObj,sourceObj)
 		var result1 = diff(defaultsObj,sourceObj1)
-		
+		var result2 = diff(defaultsObj,sourceObj2)
+
 		expect(result).to.deep.equal({})
 		expect(result1).to.deep.equal(sourceObj1)
+		expect(result2).to.deep.equal(sourceObj2)
+
 	})
 })


### PR DESCRIPTION
I think that fix will help when we try to compare different objects that are missing in the other. Can be considered as new changes.
